### PR TITLE
feat: Phase 2 - EdgeBinder Integration with Adapter Registry

### DIFF
--- a/EXTENSIBLE_ADAPTER_SYSTEM.md
+++ b/EXTENSIBLE_ADAPTER_SYSTEM.md
@@ -278,47 +278,54 @@ class AdapterException extends EdgeBinderException
 - Updated `composer.json` autoload paths
 - PHPStan configuration updated if needed
 
-### Phase 2: Integration with EdgeBinder Core (Week 2)
+### Phase 2: Integration with EdgeBinder Core (Week 2) ✅ COMPLETED
 
 #### Acceptance Criteria
-- [ ] `EdgeBinder` class can discover and use registered adapters
-- [ ] Framework components can integrate with the registry
-- [ ] Configuration format supports third-party adapters
-- [ ] Backward compatibility is maintained for existing adapters
-- [ ] Integration tests pass with mock third-party adapters
-- [ ] Documentation includes integration examples
+- [x] `EdgeBinder` class can discover and use registered adapters
+- [x] Framework components can integrate with the registry
+- [x] Configuration format supports third-party adapters
+- [x] Backward compatibility is maintained for existing adapters
+- [x] Integration tests pass with mock third-party adapters
+- [x] Documentation includes integration examples
 
-#### Tasks
-1. **Update EdgeBinder Class** (`src/EdgeBinder.php`)
-   - Add adapter discovery logic to constructor or factory methods
-   - Support registry-based adapter creation
-   - Maintain backward compatibility with existing adapters
-   - Add configuration validation for third-party adapters
+#### Tasks ✅ COMPLETED
+1. **Update EdgeBinder Class** (`src/EdgeBinder.php`) ✅
+   - ✅ Added factory methods `fromConfiguration()` and `fromAdapter()`
+   - ✅ Support registry-based adapter creation through AdapterRegistry
+   - ✅ Maintained backward compatibility with existing constructor
+   - ✅ Added comprehensive configuration validation with helpful error messages
 
-2. **Configuration Format Updates**
-   - Define standard configuration structure for third-party adapters
-   - Ensure configuration is framework-agnostic
-   - Support both simple and complex adapter configurations
-   - Add validation for required configuration keys
+2. **Configuration Format Updates** ✅
+   - ✅ Defined standard configuration structure for third-party adapters
+   - ✅ Ensured configuration is framework-agnostic (flat structure)
+   - ✅ Support both simple and complex adapter configurations
+   - ✅ Added validation for required configuration keys ('adapter' key)
 
-3. **Integration Points**
-   - Define how framework components discover registered adapters
-   - Create helper methods for building adapter configurations
-   - Ensure PSR-11 container access is properly passed to adapters
-   - Handle adapter creation errors gracefully
+3. **Integration Points** ✅
+   - ✅ Framework components can use `EdgeBinder::fromConfiguration()` for discovery
+   - ✅ Configuration transformation from flat to AdapterFactoryInterface format
+   - ✅ PSR-11 container access properly passed to adapters via config structure
+   - ✅ Graceful error handling with AdapterException wrapping
 
-4. **Integration Tests**
-   - Create mock third-party adapter for testing
-   - Test adapter registration and discovery flow
-   - Test configuration passing and validation
-   - Test error handling in integration scenarios
-   - Test multiple adapter types working together
+4. **Integration Tests** ✅
+   - ✅ Created MockAdapterFactory and MockAdapter for testing
+   - ✅ Tested adapter registration and discovery flow
+   - ✅ Tested configuration passing and validation
+   - ✅ Tested error handling in integration scenarios
+   - ✅ Tested multiple adapter types working together
 
-#### Deliverables
-- Updated `EdgeBinder` class with adapter discovery
-- Integration test suite with mock adapters
-- Configuration format documentation
-- Framework integration guidelines
+#### Deliverables ✅ COMPLETED
+- ✅ Updated `EdgeBinder` class with adapter discovery via factory methods
+- ✅ Integration test suite with mock adapters (`tests/Integration/`)
+- ✅ Configuration format documentation in `llms.txt`
+- ✅ Framework integration guidelines and examples in `llms.txt`
+
+**Files Implemented:**
+- `src/EdgeBinder.php` - Added `fromConfiguration()` and `fromAdapter()` factory methods
+- `tests/Integration/EdgeBinderFactoryTest.php` - Factory method tests
+- `tests/Integration/AdapterRegistryIntegrationTest.php` - Complete workflow tests
+- `tests/Integration/MockAdapterFactory.php` - Mock adapter for testing
+- Updated `llms.txt` with Phase 2 documentation and examples
 
 ### Phase 3: Documentation and Examples (Week 3)
 

--- a/llms.txt
+++ b/llms.txt
@@ -140,6 +140,133 @@ class AdapterException extends EdgeBinderException
 - Configuration validation and normalization support
 - Testing utilities for clean test environments
 
+### Phase 2 Implementation Status: ✅ COMPLETED
+
+**EdgeBinder Integration Implemented:**
+- ✅ Factory methods added to EdgeBinder class for configuration-based creation
+- ✅ Registry-based adapter discovery and creation
+- ✅ Backward compatibility maintained with existing constructor
+- ✅ Configuration validation with helpful error messages
+- ✅ Integration tests with mock third-party adapters
+
+**New EdgeBinder Factory Methods:**
+```php
+// Create EdgeBinder from configuration using registered adapters
+EdgeBinder::fromConfiguration(array $config, ContainerInterface $container, array $globalConfig = []): EdgeBinder
+
+// Create EdgeBinder from adapter (backward compatibility)
+EdgeBinder::fromAdapter(PersistenceAdapterInterface $adapter): EdgeBinder
+```
+
+**Configuration Format:**
+```php
+$config = [
+    'adapter' => 'weaviate',  // Required: adapter type
+    'weaviate_client' => 'weaviate.client.rag',  // Client service name
+    'collection_name' => 'RAGBindings',  // Adapter-specific config
+    'schema' => ['auto_create' => true],  // More adapter-specific config
+];
+
+$edgeBinder = EdgeBinder::fromConfiguration($config, $container, $globalConfig);
+```
+
+**Integration Test Coverage:**
+- ✅ `tests/Integration/EdgeBinderFactoryTest.php` - Tests factory methods and configuration validation
+- ✅ `tests/Integration/AdapterRegistryIntegrationTest.php` - Tests complete workflow from registration to usage
+- ✅ `tests/Integration/MockAdapterFactory.php` - Mock adapter factory for testing
+
+**Key Features Delivered:**
+- Framework-agnostic EdgeBinder creation from configuration
+- Automatic adapter discovery through registry
+- Configuration structure transformation for AdapterFactoryInterface
+- Comprehensive error handling with context-aware messages
+- Full backward compatibility with existing EdgeBinder constructor
+- Mock adapters and factories for comprehensive testing
+
+## Using EdgeBinder with Registered Adapters
+
+### Framework Integration Examples
+
+#### Laminas/Mezzio
+```php
+// In Module.php or application bootstrap
+use EdgeBinder\Registry\AdapterRegistry;
+use MyVendor\WeaviateAdapter\WeaviateAdapterFactory;
+
+// Register adapter factory
+AdapterRegistry::register(new WeaviateAdapterFactory());
+
+// In your service factory
+public function __invoke(ContainerInterface $container): EdgeBinder
+{
+    $config = $container->get('config')['edgebinder']['rag'];
+    return EdgeBinder::fromConfiguration($config, $container);
+}
+```
+
+#### Symfony
+```php
+// In bundle boot method or compiler pass
+use EdgeBinder\Registry\AdapterRegistry;
+
+foreach ($container->findTaggedServiceIds('edgebinder.adapter_factory') as $id => $tags) {
+    $factory = $container->get($id);
+    AdapterRegistry::register($factory);
+}
+
+// In your service
+public function createEdgeBinder(ContainerInterface $container): EdgeBinder
+{
+    $config = $container->getParameter('edgebinder.rag');
+    return EdgeBinder::fromConfiguration($config, $container);
+}
+```
+
+#### Laravel
+```php
+// In service provider boot method
+use EdgeBinder\Registry\AdapterRegistry;
+
+public function boot()
+{
+    AdapterRegistry::register(new WeaviateAdapterFactory());
+}
+
+// In your service
+public function createEdgeBinder(): EdgeBinder
+{
+    $config = config('edgebinder.rag');
+    return EdgeBinder::fromConfiguration($config, app());
+}
+```
+
+#### Generic PHP
+```php
+// Anywhere in application bootstrap
+use EdgeBinder\Registry\AdapterRegistry;
+use EdgeBinder\EdgeBinder;
+
+// Register adapters
+AdapterRegistry::register(new WeaviateAdapterFactory());
+AdapterRegistry::register(new JanusAdapterFactory());
+
+// Create EdgeBinder instances
+$ragConfig = [
+    'adapter' => 'weaviate',
+    'weaviate_client' => 'weaviate.client.rag',
+    'collection_name' => 'RAGBindings',
+];
+
+$socialConfig = [
+    'adapter' => 'janus',
+    'janus_client' => 'janus.client.social',
+    'graph_name' => 'SocialNetwork',
+];
+
+$ragBinder = EdgeBinder::fromConfiguration($ragConfig, $container);
+$socialBinder = EdgeBinder::fromConfiguration($socialConfig, $container);
+```
+
 ## Creating New Adapters
 
 ### Step 1: Implement PersistenceAdapterInterface

--- a/src/EdgeBinder.php
+++ b/src/EdgeBinder.php
@@ -8,10 +8,10 @@ use EdgeBinder\Contracts\BindingInterface;
 use EdgeBinder\Contracts\EdgeBinderInterface;
 use EdgeBinder\Contracts\PersistenceAdapterInterface;
 use EdgeBinder\Contracts\QueryBuilderInterface;
+use EdgeBinder\Exception\AdapterException;
 use EdgeBinder\Exception\BindingNotFoundException;
 use EdgeBinder\Exception\InvalidMetadataException;
 use EdgeBinder\Exception\PersistenceException;
-use EdgeBinder\Exception\AdapterException;
 use EdgeBinder\Query\BindingQueryBuilder;
 use EdgeBinder\Registry\AdapterRegistry;
 use Psr\Container\ContainerInterface;
@@ -71,14 +71,14 @@ final class EdgeBinder implements EdgeBinderInterface
      * $edgeBinder = EdgeBinder::fromConfiguration($config, app());
      * ```
      *
-     * @param array<string, mixed>  $config       Instance configuration containing adapter type and settings
-     * @param ContainerInterface    $container    PSR-11 container for dependency injection
-     * @param array<string, mixed>  $globalConfig Optional global EdgeBinder configuration
+     * @param array<string, mixed> $config       Instance configuration containing adapter type and settings
+     * @param ContainerInterface   $container    PSR-11 container for dependency injection
+     * @param array<string, mixed> $globalConfig Optional global EdgeBinder configuration
      *
      * @return self Configured EdgeBinder instance
      *
      * @throws \InvalidArgumentException If required configuration is missing
-     * @throws AdapterException         If adapter type is not registered or creation fails
+     * @throws AdapterException          If adapter type is not registered or creation fails
      */
     public static function fromConfiguration(
         array $config,
@@ -87,17 +87,12 @@ final class EdgeBinder implements EdgeBinderInterface
     ): self {
         // Validate required configuration
         if (!isset($config['adapter'])) {
-            throw new \InvalidArgumentException(
-                "Configuration must contain 'adapter' key specifying the adapter type. " .
-                "Available types: " . implode(', ', AdapterRegistry::getRegisteredTypes())
-            );
+            throw new \InvalidArgumentException("Configuration must contain 'adapter' key specifying the adapter type. ".'Available types: '.implode(', ', AdapterRegistry::getRegisteredTypes()));
         }
 
         $adapterType = $config['adapter'];
         if (!is_string($adapterType) || empty($adapterType)) {
-            throw new \InvalidArgumentException(
-                "Adapter type must be a non-empty string, got: " . gettype($adapterType)
-            );
+            throw new \InvalidArgumentException('Adapter type must be a non-empty string, got: '.gettype($adapterType));
         }
 
         // Build adapter configuration structure expected by AdapterFactoryInterface

--- a/tests/Integration/AdapterRegistryIntegrationTest.php
+++ b/tests/Integration/AdapterRegistryIntegrationTest.php
@@ -1,0 +1,238 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EdgeBinder\Tests\Integration;
+
+use EdgeBinder\EdgeBinder;
+use EdgeBinder\Exception\AdapterException;
+use EdgeBinder\Registry\AdapterRegistry;
+use PHPUnit\Framework\TestCase;
+use Psr\Container\ContainerInterface;
+
+/**
+ * Integration tests for the complete adapter registry workflow.
+ *
+ * These tests verify that the entire flow from adapter registration
+ * to EdgeBinder creation and usage works correctly.
+ */
+final class AdapterRegistryIntegrationTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        // Clear registry before each test for clean isolation
+        AdapterRegistry::clear();
+    }
+
+    protected function tearDown(): void
+    {
+        // Clear registry after each test for clean isolation
+        AdapterRegistry::clear();
+    }
+
+    public function testCompleteWorkflowFromRegistrationToUsage(): void
+    {
+        // Step 1: Register a mock adapter factory
+        $mockFactory = new MockAdapterFactory('redis');
+        AdapterRegistry::register($mockFactory);
+
+        // Verify adapter is registered
+        $this->assertTrue(AdapterRegistry::hasAdapter('redis'));
+        $this->assertContains('redis', AdapterRegistry::getRegisteredTypes());
+
+        // Step 2: Create container mock with client service
+        $container = $this->createMock(ContainerInterface::class);
+        $container->method('get')
+            ->with('redis.client.cache')
+            ->willReturn(new \stdClass()); // Mock Redis client
+
+        // Step 3: Create EdgeBinder from configuration
+        $config = [
+            'adapter' => 'redis',
+            'redis_client' => 'redis.client.cache',
+            'ttl' => 3600,
+            'prefix' => 'edgebinder:',
+        ];
+
+        $edgeBinder = EdgeBinder::fromConfiguration($config, $container);
+
+        // Step 4: Verify EdgeBinder works with the adapter
+        $this->assertInstanceOf(EdgeBinder::class, $edgeBinder);
+
+        // Create test entities
+        $user = new TestEntity('user-123', 'User');
+        $project = new TestEntity('project-456', 'Project');
+
+        // Step 5: Test binding creation
+        $binding = $edgeBinder->bind(
+            from: $user,
+            to: $project,
+            type: 'has_access',
+            metadata: ['level' => 'admin']
+        );
+
+        $this->assertNotNull($binding);
+        $this->assertEquals('has_access', $binding->getType());
+        $this->assertEquals(['level' => 'admin'], $binding->getMetadata());
+
+        // Step 6: Test querying
+        $bindings = $edgeBinder->findBindingsFor($user);
+        $this->assertCount(1, $bindings);
+        $this->assertEquals($binding->getId(), $bindings[0]->getId());
+
+        // Step 7: Test relationship checking
+        $this->assertTrue($edgeBinder->areBound($user, $project, 'has_access'));
+        $this->assertFalse($edgeBinder->areBound($user, $project, 'different_type'));
+    }
+
+    public function testMultipleAdapterTypesCanBeRegistered(): void
+    {
+        // Register multiple adapter types
+        AdapterRegistry::register(new MockAdapterFactory('redis'));
+        AdapterRegistry::register(new MockAdapterFactory('weaviate'));
+        AdapterRegistry::register(new MockAdapterFactory('janus'));
+
+        // Verify all are registered
+        $types = AdapterRegistry::getRegisteredTypes();
+        $this->assertContains('redis', $types);
+        $this->assertContains('weaviate', $types);
+        $this->assertContains('janus', $types);
+
+        // Create EdgeBinder instances with different adapters
+        $container = $this->createMock(ContainerInterface::class);
+
+        $redisEdgeBinder = EdgeBinder::fromConfiguration(
+            ['adapter' => 'redis', 'redis_client' => 'redis.client'],
+            $container
+        );
+
+        $weaviateEdgeBinder = EdgeBinder::fromConfiguration(
+            ['adapter' => 'weaviate', 'weaviate_client' => 'weaviate.client'],
+            $container
+        );
+
+        $this->assertInstanceOf(EdgeBinder::class, $redisEdgeBinder);
+        $this->assertInstanceOf(EdgeBinder::class, $weaviateEdgeBinder);
+
+        // Verify they use different adapters
+        $this->assertNotSame(
+            $redisEdgeBinder->getStorageAdapter(),
+            $weaviateEdgeBinder->getStorageAdapter()
+        );
+    }
+
+    public function testAdapterFactoryReceivesCorrectConfigurationStructure(): void
+    {
+        // Create a factory that validates the configuration structure
+        $factory = new class implements \EdgeBinder\Registry\AdapterFactoryInterface {
+            public array $receivedConfig = [];
+
+            public function createAdapter(array $config): \EdgeBinder\Contracts\PersistenceAdapterInterface
+            {
+                $this->receivedConfig = $config;
+
+                // Validate the expected structure
+                if (!isset($config['instance'], $config['global'], $config['container'])) {
+                    throw new \InvalidArgumentException('Invalid configuration structure');
+                }
+
+                return new MockAdapter($config);
+            }
+
+            public function getAdapterType(): string
+            {
+                return 'test';
+            }
+        };
+
+        AdapterRegistry::register($factory);
+
+        $container = $this->createMock(ContainerInterface::class);
+        $config = [
+            'adapter' => 'test',
+            'test_client' => 'test.client.default',
+            'host' => 'localhost',
+            'port' => 1234,
+        ];
+        $globalConfig = ['debug' => true];
+
+        EdgeBinder::fromConfiguration($config, $container, $globalConfig);
+
+        // Verify the factory received the correct configuration structure
+        $this->assertArrayHasKey('instance', $factory->receivedConfig);
+        $this->assertArrayHasKey('global', $factory->receivedConfig);
+        $this->assertArrayHasKey('container', $factory->receivedConfig);
+
+        // Verify instance config contains our original config
+        $this->assertEquals($config, $factory->receivedConfig['instance']);
+
+        // Verify global config was passed
+        $this->assertEquals($globalConfig, $factory->receivedConfig['global']);
+
+        // Verify container was passed
+        $this->assertSame($container, $factory->receivedConfig['container']);
+    }
+
+    public function testErrorHandlingForAdapterCreationFailure(): void
+    {
+        // Register a factory that throws an exception
+        $factory = new class implements \EdgeBinder\Registry\AdapterFactoryInterface {
+            public function createAdapter(array $config): \EdgeBinder\Contracts\PersistenceAdapterInterface
+            {
+                throw new \RuntimeException('Database connection failed');
+            }
+
+            public function getAdapterType(): string
+            {
+                return 'failing';
+            }
+        };
+
+        AdapterRegistry::register($factory);
+
+        $container = $this->createMock(ContainerInterface::class);
+        $config = ['adapter' => 'failing'];
+
+        $this->expectException(AdapterException::class);
+        $this->expectExceptionMessage("Failed to create adapter of type 'failing': Database connection failed");
+
+        EdgeBinder::fromConfiguration($config, $container);
+    }
+
+    public function testConfigurationValidationWithHelpfulErrorMessages(): void
+    {
+        // Register an adapter so we have available types
+        AdapterRegistry::register(new MockAdapterFactory('redis'));
+
+        $container = $this->createMock(ContainerInterface::class);
+
+        // Test missing adapter key
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage("Configuration must contain 'adapter' key");
+        $this->expectExceptionMessage("Available types: redis");
+
+        EdgeBinder::fromConfiguration([], $container);
+    }
+}
+
+/**
+ * Simple test entity for integration testing.
+ */
+class TestEntity
+{
+    public function __construct(
+        private readonly string $id,
+        private readonly string $type
+    ) {
+    }
+
+    public function getId(): string
+    {
+        return $this->id;
+    }
+
+    public function getType(): string
+    {
+        return $this->type;
+    }
+}

--- a/tests/Integration/AdapterRegistryIntegrationTest.php
+++ b/tests/Integration/AdapterRegistryIntegrationTest.php
@@ -210,7 +210,7 @@ final class AdapterRegistryIntegrationTest extends TestCase
         // Test missing adapter key
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage("Configuration must contain 'adapter' key");
-        $this->expectExceptionMessage("Available types: redis");
+        $this->expectExceptionMessage('Available types: redis');
 
         EdgeBinder::fromConfiguration([], $container);
     }

--- a/tests/Integration/AdapterRegistryIntegrationTest.php
+++ b/tests/Integration/AdapterRegistryIntegrationTest.php
@@ -125,6 +125,7 @@ final class AdapterRegistryIntegrationTest extends TestCase
     {
         // Create a factory that validates the configuration structure
         $factory = new class implements \EdgeBinder\Registry\AdapterFactoryInterface {
+            /** @var array<string, mixed> */
             public array $receivedConfig = [];
 
             public function createAdapter(array $config): \EdgeBinder\Contracts\PersistenceAdapterInterface

--- a/tests/Integration/EdgeBinderFactoryTest.php
+++ b/tests/Integration/EdgeBinderFactoryTest.php
@@ -1,0 +1,244 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EdgeBinder\Tests\Integration;
+
+use EdgeBinder\Contracts\BindingInterface;
+use EdgeBinder\Contracts\PersistenceAdapterInterface;
+use EdgeBinder\Contracts\QueryBuilderInterface;
+use EdgeBinder\EdgeBinder;
+use EdgeBinder\Exception\AdapterException;
+use EdgeBinder\Registry\AdapterFactoryInterface;
+use EdgeBinder\Registry\AdapterRegistry;
+use PHPUnit\Framework\TestCase;
+use Psr\Container\ContainerInterface;
+
+/**
+ * Integration tests for EdgeBinder factory methods and adapter registry integration.
+ */
+final class EdgeBinderFactoryTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        // Clear registry before each test for clean isolation
+        AdapterRegistry::clear();
+    }
+
+    protected function tearDown(): void
+    {
+        // Clear registry after each test for clean isolation
+        AdapterRegistry::clear();
+    }
+
+    public function testFromConfigurationCreatesEdgeBinderWithRegisteredAdapter(): void
+    {
+        // Register a mock adapter factory
+        $mockAdapter = $this->createMockAdapter();
+        $mockFactory = $this->createMockAdapterFactory('test', $mockAdapter);
+        AdapterRegistry::register($mockFactory);
+
+        // Create container mock
+        $container = $this->createMock(ContainerInterface::class);
+
+        // Configuration
+        $config = [
+            'adapter' => 'test',
+            'test_client' => 'test.client.default',
+            'host' => 'localhost',
+            'port' => 1234,
+        ];
+
+        // Create EdgeBinder from configuration
+        $edgeBinder = EdgeBinder::fromConfiguration($config, $container);
+
+        // Verify it's an EdgeBinder instance
+        $this->assertInstanceOf(EdgeBinder::class, $edgeBinder);
+
+        // Verify the adapter was used by checking storage adapter
+        $this->assertSame($mockAdapter, $edgeBinder->getStorageAdapter());
+    }
+
+    public function testFromConfigurationWithGlobalConfig(): void
+    {
+        // Register a mock adapter factory that expects global config
+        $mockAdapter = $this->createMockAdapter();
+        $mockFactory = $this->createMockAdapterFactoryWithGlobalConfig('test', $mockAdapter);
+        AdapterRegistry::register($mockFactory);
+
+        // Create container mock
+        $container = $this->createMock(ContainerInterface::class);
+
+        // Configuration
+        $config = [
+            'adapter' => 'test',
+            'test_client' => 'test.client.default',
+        ];
+
+        $globalConfig = [
+            'default_metadata_validation' => true,
+            'entity_extraction_strategy' => 'reflection',
+        ];
+
+        // Create EdgeBinder from configuration
+        $edgeBinder = EdgeBinder::fromConfiguration($config, $container, $globalConfig);
+
+        // Verify it's an EdgeBinder instance
+        $this->assertInstanceOf(EdgeBinder::class, $edgeBinder);
+        $this->assertSame($mockAdapter, $edgeBinder->getStorageAdapter());
+    }
+
+    public function testFromConfigurationThrowsExceptionForMissingAdapterKey(): void
+    {
+        $container = $this->createMock(ContainerInterface::class);
+
+        // Configuration missing 'adapter' key
+        $config = [
+            'host' => 'localhost',
+            'port' => 1234,
+        ];
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage("Configuration must contain 'adapter' key");
+
+        EdgeBinder::fromConfiguration($config, $container);
+    }
+
+    public function testFromConfigurationThrowsExceptionForInvalidAdapterType(): void
+    {
+        $container = $this->createMock(ContainerInterface::class);
+
+        // Configuration with invalid adapter type
+        $config = [
+            'adapter' => 123, // Should be string
+        ];
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage("Adapter type must be a non-empty string");
+
+        EdgeBinder::fromConfiguration($config, $container);
+    }
+
+    public function testFromConfigurationThrowsExceptionForEmptyAdapterType(): void
+    {
+        $container = $this->createMock(ContainerInterface::class);
+
+        // Configuration with empty adapter type
+        $config = [
+            'adapter' => '',
+        ];
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage("Adapter type must be a non-empty string");
+
+        EdgeBinder::fromConfiguration($config, $container);
+    }
+
+    public function testFromConfigurationThrowsExceptionForUnregisteredAdapter(): void
+    {
+        $container = $this->createMock(ContainerInterface::class);
+
+        // Configuration with unregistered adapter type
+        $config = [
+            'adapter' => 'nonexistent',
+        ];
+
+        $this->expectException(AdapterException::class);
+        $this->expectExceptionMessage("Adapter factory for type 'nonexistent' not found");
+
+        EdgeBinder::fromConfiguration($config, $container);
+    }
+
+    public function testFromAdapterCreatesEdgeBinderInstance(): void
+    {
+        $mockAdapter = $this->createMockAdapter();
+
+        $edgeBinder = EdgeBinder::fromAdapter($mockAdapter);
+
+        $this->assertInstanceOf(EdgeBinder::class, $edgeBinder);
+        $this->assertSame($mockAdapter, $edgeBinder->getStorageAdapter());
+    }
+
+    public function testBackwardCompatibilityWithDirectConstructor(): void
+    {
+        $mockAdapter = $this->createMockAdapter();
+
+        // Direct constructor should still work
+        $edgeBinder = new EdgeBinder($mockAdapter);
+
+        $this->assertInstanceOf(EdgeBinder::class, $edgeBinder);
+        $this->assertSame($mockAdapter, $edgeBinder->getStorageAdapter());
+    }
+
+    public function testAdapterFactoryReceivesCorrectConfiguration(): void
+    {
+        $container = $this->createMock(ContainerInterface::class);
+        $mockAdapter = $this->createMockAdapter();
+
+        // Create a factory that verifies the configuration structure
+        $mockFactory = $this->createMock(AdapterFactoryInterface::class);
+        $mockFactory->method('getAdapterType')->willReturn('test');
+        $mockFactory->expects($this->once())
+            ->method('createAdapter')
+            ->with($this->callback(function (array $config) use ($container): bool {
+                // Verify the configuration structure matches AdapterFactoryInterface expectations
+                $this->assertArrayHasKey('instance', $config);
+                $this->assertArrayHasKey('global', $config);
+                $this->assertArrayHasKey('container', $config);
+
+                // Verify instance config contains our original config
+                $this->assertEquals('test', $config['instance']['adapter']);
+                $this->assertEquals('test.client.default', $config['instance']['test_client']);
+                $this->assertEquals('localhost', $config['instance']['host']);
+
+                // Verify container is passed through
+                $this->assertSame($container, $config['container']);
+
+                return true;
+            }))
+            ->willReturn($mockAdapter);
+
+        AdapterRegistry::register($mockFactory);
+
+        $config = [
+            'adapter' => 'test',
+            'test_client' => 'test.client.default',
+            'host' => 'localhost',
+        ];
+
+        $globalConfig = ['some' => 'global_config'];
+
+        EdgeBinder::fromConfiguration($config, $container, $globalConfig);
+    }
+
+    private function createMockAdapter(): PersistenceAdapterInterface
+    {
+        return $this->createMock(PersistenceAdapterInterface::class);
+    }
+
+    private function createMockAdapterFactory(string $type, PersistenceAdapterInterface $adapter): AdapterFactoryInterface
+    {
+        $factory = $this->createMock(AdapterFactoryInterface::class);
+        $factory->method('getAdapterType')->willReturn($type);
+        $factory->method('createAdapter')->willReturn($adapter);
+
+        return $factory;
+    }
+
+    private function createMockAdapterFactoryWithGlobalConfig(string $type, PersistenceAdapterInterface $adapter): AdapterFactoryInterface
+    {
+        $factory = $this->createMock(AdapterFactoryInterface::class);
+        $factory->method('getAdapterType')->willReturn($type);
+        $factory->expects($this->once())
+            ->method('createAdapter')
+            ->with($this->callback(function (array $config): bool {
+                // Verify global config is passed
+                $this->assertArrayHasKey('global', $config);
+                $this->assertEquals('reflection', $config['global']['entity_extraction_strategy']);
+                return true;
+            }))
+            ->willReturn($adapter);
+
+        return $factory;
+    }
+}

--- a/tests/Integration/EdgeBinderFactoryTest.php
+++ b/tests/Integration/EdgeBinderFactoryTest.php
@@ -4,9 +4,7 @@ declare(strict_types=1);
 
 namespace EdgeBinder\Tests\Integration;
 
-use EdgeBinder\Contracts\BindingInterface;
 use EdgeBinder\Contracts\PersistenceAdapterInterface;
-use EdgeBinder\Contracts\QueryBuilderInterface;
 use EdgeBinder\EdgeBinder;
 use EdgeBinder\Exception\AdapterException;
 use EdgeBinder\Registry\AdapterFactoryInterface;
@@ -114,7 +112,7 @@ final class EdgeBinderFactoryTest extends TestCase
         ];
 
         $this->expectException(\InvalidArgumentException::class);
-        $this->expectExceptionMessage("Adapter type must be a non-empty string");
+        $this->expectExceptionMessage('Adapter type must be a non-empty string');
 
         EdgeBinder::fromConfiguration($config, $container);
     }
@@ -129,7 +127,7 @@ final class EdgeBinderFactoryTest extends TestCase
         ];
 
         $this->expectException(\InvalidArgumentException::class);
-        $this->expectExceptionMessage("Adapter type must be a non-empty string");
+        $this->expectExceptionMessage('Adapter type must be a non-empty string');
 
         EdgeBinder::fromConfiguration($config, $container);
     }
@@ -235,6 +233,7 @@ final class EdgeBinderFactoryTest extends TestCase
                 // Verify global config is passed
                 $this->assertArrayHasKey('global', $config);
                 $this->assertEquals('reflection', $config['global']['entity_extraction_strategy']);
+
                 return true;
             }))
             ->willReturn($adapter);

--- a/tests/Integration/MockAdapterFactory.php
+++ b/tests/Integration/MockAdapterFactory.php
@@ -76,6 +76,12 @@ final class MockAdapter implements PersistenceAdapterInterface
         return array_values($this->bindings);
     }
 
+    public function count(QueryBuilderInterface $query): int
+    {
+        // Simple implementation for testing - just return count of all bindings
+        return count($this->bindings);
+    }
+
     public function extractEntityId(object $entity): string
     {
         // Simple implementation for testing

--- a/tests/Integration/MockAdapterFactory.php
+++ b/tests/Integration/MockAdapterFactory.php
@@ -47,9 +47,13 @@ final class MockAdapterFactory implements AdapterFactoryInterface
  */
 final class MockAdapter implements PersistenceAdapterInterface
 {
+    /** @var array<string, BindingInterface> */
     private array $bindings = [];
+
+    /** @var array<string, mixed> */
     private array $config;
 
+    /** @param array<string, mixed> $config */
     public function __construct(array $config)
     {
         $this->config = $config;
@@ -165,6 +169,7 @@ final class MockAdapter implements PersistenceAdapterInterface
             $updatedBinding = new class($binding, $metadata) implements BindingInterface {
                 public function __construct(
                     private readonly BindingInterface $original,
+                    /** @var array<string, mixed> */
                     private readonly array $newMetadata
                 ) {
                 }
@@ -214,6 +219,22 @@ final class MockAdapter implements PersistenceAdapterInterface
                     return new \DateTimeImmutable();
                 }
 
+                public function withMetadata(array $metadata): static
+                {
+                    return new self($this->original, $metadata);
+                }
+
+                public function connects(string $fromType, string $fromId, string $toType, string $toId): bool
+                {
+                    return $this->original->connects($fromType, $fromId, $toType, $toId);
+                }
+
+                public function involves(string $entityType, string $entityId): bool
+                {
+                    return $this->original->involves($entityType, $entityId);
+                }
+
+                /** @return array<string, mixed> */
                 public function toArray(): array
                 {
                     return [
@@ -239,6 +260,8 @@ final class MockAdapter implements PersistenceAdapterInterface
      *
      * This method is useful for testing to verify that configuration
      * was passed correctly from the factory.
+     *
+     * @return array<string, mixed>
      */
     public function getConfig(): array
     {

--- a/tests/Integration/MockAdapterFactory.php
+++ b/tests/Integration/MockAdapterFactory.php
@@ -26,7 +26,7 @@ final class MockAdapterFactory implements AdapterFactoryInterface
     public function createAdapter(array $config): PersistenceAdapterInterface
     {
         // Return pre-configured adapter if provided, otherwise create a new mock
-        if ($this->adapter !== null) {
+        if (null !== $this->adapter) {
             return $this->adapter;
         }
 
@@ -120,11 +120,12 @@ final class MockAdapter implements PersistenceAdapterInterface
     {
         $result = [];
         foreach ($this->bindings as $binding) {
-            if (($binding->getFromType() === $entityType && $binding->getFromId() === $entityId) ||
-                ($binding->getToType() === $entityType && $binding->getToId() === $entityId)) {
+            if (($binding->getFromType() === $entityType && $binding->getFromId() === $entityId)
+                || ($binding->getToType() === $entityType && $binding->getToId() === $entityId)) {
                 $result[] = $binding;
             }
         }
+
         return $result;
     }
 
@@ -137,14 +138,15 @@ final class MockAdapter implements PersistenceAdapterInterface
     ): array {
         $result = [];
         foreach ($this->bindings as $binding) {
-            if ($binding->getFromType() === $fromType &&
-                $binding->getFromId() === $fromId &&
-                $binding->getToType() === $toType &&
-                $binding->getToId() === $toId &&
-                ($bindingType === null || $binding->getType() === $bindingType)) {
+            if ($binding->getFromType() === $fromType
+                && $binding->getFromId() === $fromId
+                && $binding->getToType() === $toType
+                && $binding->getToId() === $toId
+                && (null === $bindingType || $binding->getType() === $bindingType)) {
                 $result[] = $binding;
             }
         }
+
         return $result;
     }
 
@@ -152,12 +154,13 @@ final class MockAdapter implements PersistenceAdapterInterface
     {
         $deletedCount = 0;
         foreach ($this->bindings as $id => $binding) {
-            if (($binding->getFromType() === $entityType && $binding->getFromId() === $entityId) ||
-                ($binding->getToType() === $entityType && $binding->getToId() === $entityId)) {
+            if (($binding->getFromType() === $entityType && $binding->getFromId() === $entityId)
+                || ($binding->getToType() === $entityType && $binding->getToId() === $entityId)) {
                 unset($this->bindings[$id]);
-                $deletedCount++;
+                ++$deletedCount;
             }
         }
+
         return $deletedCount;
     }
 

--- a/tests/Integration/MockAdapterFactory.php
+++ b/tests/Integration/MockAdapterFactory.php
@@ -1,0 +1,241 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EdgeBinder\Tests\Integration;
+
+use EdgeBinder\Contracts\BindingInterface;
+use EdgeBinder\Contracts\PersistenceAdapterInterface;
+use EdgeBinder\Contracts\QueryBuilderInterface;
+use EdgeBinder\Registry\AdapterFactoryInterface;
+
+/**
+ * Mock adapter factory for integration testing.
+ *
+ * This factory creates mock adapters that can be used to test the
+ * adapter registry integration without requiring real storage backends.
+ */
+final class MockAdapterFactory implements AdapterFactoryInterface
+{
+    public function __construct(
+        private readonly string $adapterType = 'mock',
+        private readonly ?PersistenceAdapterInterface $adapter = null
+    ) {
+    }
+
+    public function createAdapter(array $config): PersistenceAdapterInterface
+    {
+        // Return pre-configured adapter if provided, otherwise create a new mock
+        if ($this->adapter !== null) {
+            return $this->adapter;
+        }
+
+        return new MockAdapter($config);
+    }
+
+    public function getAdapterType(): string
+    {
+        return $this->adapterType;
+    }
+}
+
+/**
+ * Mock persistence adapter for testing.
+ *
+ * This adapter provides a minimal implementation that can be used
+ * for testing the EdgeBinder integration without real storage.
+ */
+final class MockAdapter implements PersistenceAdapterInterface
+{
+    private array $bindings = [];
+    private array $config;
+
+    public function __construct(array $config)
+    {
+        $this->config = $config;
+    }
+
+    public function store(BindingInterface $binding): void
+    {
+        $this->bindings[$binding->getId()] = $binding;
+    }
+
+    public function find(string $bindingId): ?BindingInterface
+    {
+        return $this->bindings[$bindingId] ?? null;
+    }
+
+    public function delete(string $bindingId): void
+    {
+        unset($this->bindings[$bindingId]);
+    }
+
+    public function executeQuery(QueryBuilderInterface $query): array
+    {
+        // Simple implementation for testing
+        return array_values($this->bindings);
+    }
+
+    public function extractEntityId(object $entity): string
+    {
+        // Simple implementation for testing
+        if (method_exists($entity, 'getId')) {
+            return (string) $entity->getId();
+        }
+
+        if (property_exists($entity, 'id')) {
+            return (string) $entity->id;
+        }
+
+        return spl_object_hash($entity);
+    }
+
+    public function extractEntityType(object $entity): string
+    {
+        // Simple implementation for testing
+        if (method_exists($entity, 'getType')) {
+            return $entity->getType();
+        }
+
+        return get_class($entity);
+    }
+
+    public function validateAndNormalizeMetadata(array $metadata): array
+    {
+        // Simple implementation for testing - just return as-is
+        return $metadata;
+    }
+
+    public function findByEntity(string $entityType, string $entityId): array
+    {
+        $result = [];
+        foreach ($this->bindings as $binding) {
+            if (($binding->getFromType() === $entityType && $binding->getFromId() === $entityId) ||
+                ($binding->getToType() === $entityType && $binding->getToId() === $entityId)) {
+                $result[] = $binding;
+            }
+        }
+        return $result;
+    }
+
+    public function findBetweenEntities(
+        string $fromType,
+        string $fromId,
+        string $toType,
+        string $toId,
+        ?string $bindingType = null
+    ): array {
+        $result = [];
+        foreach ($this->bindings as $binding) {
+            if ($binding->getFromType() === $fromType &&
+                $binding->getFromId() === $fromId &&
+                $binding->getToType() === $toType &&
+                $binding->getToId() === $toId &&
+                ($bindingType === null || $binding->getType() === $bindingType)) {
+                $result[] = $binding;
+            }
+        }
+        return $result;
+    }
+
+    public function deleteByEntity(string $entityType, string $entityId): int
+    {
+        $deletedCount = 0;
+        foreach ($this->bindings as $id => $binding) {
+            if (($binding->getFromType() === $entityType && $binding->getFromId() === $entityId) ||
+                ($binding->getToType() === $entityType && $binding->getToId() === $entityId)) {
+                unset($this->bindings[$id]);
+                $deletedCount++;
+            }
+        }
+        return $deletedCount;
+    }
+
+    public function updateMetadata(string $bindingId, array $metadata): void
+    {
+        if (isset($this->bindings[$bindingId])) {
+            // For testing purposes, we'll create a new binding with updated metadata
+            $binding = $this->bindings[$bindingId];
+            $updatedBinding = new class($binding, $metadata) implements BindingInterface {
+                public function __construct(
+                    private readonly BindingInterface $original,
+                    private readonly array $newMetadata
+                ) {
+                }
+
+                public function getId(): string
+                {
+                    return $this->original->getId();
+                }
+
+                public function getFromType(): string
+                {
+                    return $this->original->getFromType();
+                }
+
+                public function getFromId(): string
+                {
+                    return $this->original->getFromId();
+                }
+
+                public function getToType(): string
+                {
+                    return $this->original->getToType();
+                }
+
+                public function getToId(): string
+                {
+                    return $this->original->getToId();
+                }
+
+                public function getType(): string
+                {
+                    return $this->original->getType();
+                }
+
+                public function getMetadata(): array
+                {
+                    return $this->newMetadata;
+                }
+
+                public function getCreatedAt(): \DateTimeImmutable
+                {
+                    return $this->original->getCreatedAt();
+                }
+
+                public function getUpdatedAt(): \DateTimeImmutable
+                {
+                    return new \DateTimeImmutable();
+                }
+
+                public function toArray(): array
+                {
+                    return [
+                        'id' => $this->getId(),
+                        'from_type' => $this->getFromType(),
+                        'from_id' => $this->getFromId(),
+                        'to_type' => $this->getToType(),
+                        'to_id' => $this->getToId(),
+                        'type' => $this->getType(),
+                        'metadata' => $this->getMetadata(),
+                        'created_at' => $this->getCreatedAt()->format('c'),
+                        'updated_at' => $this->getUpdatedAt()->format('c'),
+                    ];
+                }
+            };
+
+            $this->bindings[$bindingId] = $updatedBinding;
+        }
+    }
+
+    /**
+     * Get the configuration passed to this adapter.
+     *
+     * This method is useful for testing to verify that configuration
+     * was passed correctly from the factory.
+     */
+    public function getConfig(): array
+    {
+        return $this->config;
+    }
+}


### PR DESCRIPTION
## Phase 2 Implementation: EdgeBinder Integration with Adapter Registry

This PR implements **Phase 2** of the extensible adapter system, integrating the adapter registry with EdgeBinder Core to enable framework-agnostic adapter discovery and creation.

### 🎯 Key Features Implemented

#### Factory Methods in EdgeBinder Class
- **`EdgeBinder::fromConfiguration()`** - Creates EdgeBinder instances from configuration using registered adapters
- **`EdgeBinder::fromAdapter()`** - Backward compatibility factory method
- Full integration with the AdapterRegistry system
- Comprehensive configuration validation with helpful error messages

#### Framework-Agnostic Configuration Support
- Standardized configuration format that works across all PHP frameworks
- Automatic transformation to AdapterFactoryInterface format
- Support for PSR-11 container dependency injection

#### Backward Compatibility
- ✅ Existing EdgeBinder constructor unchanged
- ✅ All existing code continues to work without modifications
- ✅ New factory methods are additive, not breaking

### 📁 Files Added/Modified

#### Core Implementation
- **`src/EdgeBinder.php`** - Added factory methods with comprehensive documentation

#### Integration Tests
- **`tests/Integration/EdgeBinderFactoryTest.php`** - Factory method and validation tests
- **`tests/Integration/AdapterRegistryIntegrationTest.php`** - Complete workflow tests
- **`tests/Integration/MockAdapterFactory.php`** - Mock adapter for testing

#### Documentation
- **`llms.txt`** - Updated with Phase 2 status and usage examples
- **`EXTENSIBLE_ADAPTER_SYSTEM.md`** - Marked Phase 2 as complete

### 🚀 Usage Example

```php
// Register adapter factory (done once in framework bootstrap)
AdapterRegistry::register(new WeaviateAdapterFactory());

// Create EdgeBinder from configuration
$config = [
    'adapter' => 'weaviate',
    'weaviate_client' => 'weaviate.client.rag',
    'collection_name' => 'RAGBindings',
    'schema' => ['auto_create' => true],
];

$edgeBinder = EdgeBinder::fromConfiguration($config, $container);
```

### ✅ Phase 2 Acceptance Criteria Met

- [x] EdgeBinder class can discover and use registered adapters
- [x] Framework components can integrate with the registry
- [x] Configuration format supports third-party adapters
- [x] Backward compatibility is maintained for existing adapters
- [x] Integration tests pass with mock third-party adapters
- [x] Documentation includes integration examples

### 🧪 Testing

The implementation includes comprehensive integration tests:
- Factory method functionality and error handling
- Configuration validation with helpful error messages
- Complete workflow from adapter registration to EdgeBinder usage
- Mock adapters for testing without external dependencies
- Backward compatibility verification

### 🔄 What's Next

With Phase 2 complete, the extensible adapter system now provides a solid foundation for third-party developers to create adapters that work seamlessly across all PHP frameworks. The next phases would focus on:

- **Phase 3**: Documentation and Examples
- **Phase 4**: Testing and Validation

### 📋 Checklist

- [x] Factory methods implemented with comprehensive documentation
- [x] Configuration validation with helpful error messages
- [x] Backward compatibility maintained
- [x] Integration tests created and passing
- [x] Documentation updated
- [x] All Phase 2 acceptance criteria met

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author